### PR TITLE
asg: Handle empty autoscaling groups

### DIFF
--- a/chef_solo_cup/helpers.py
+++ b/chef_solo_cup/helpers.py
@@ -98,6 +98,8 @@ def get_asg_hosts(args, dna_path):
         )
         for group in auto_scale_conn.get_all_groups():
             instance_ids = [i.instance_id for i in group.instances]
+            if not instance_ids:
+                continue
             try:
                 reservations = conn.get_all_instances(instance_ids)
             except EC2ResponseError:


### PR DESCRIPTION
If the group was empty it would cause a search for instance_id = [] which would match all hosts. Now if the hosts in the ASG are empty it will skip the group.

Closes #14
